### PR TITLE
Improve logging of command and add help text for users

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,6 +44,10 @@ func createCluster(c *cli.Context) error {
 		return err
 	}
 	log.Printf("SUCCESS: created cluster [%s]", c.String("name"))
+	log.Printf(`You can now use the cluster with:
+
+export KUBECONFIG="$(%s get-kubeconfig --name='%s')"
+kubectl cluster-info`, os.Args[0], c.String("name"))
 	return nil
 }
 
@@ -103,13 +107,11 @@ func getKubeConfig(c *cli.Context) error {
 	destPath, _ := getClusterDir(c.String("name"))
 	cmd := "docker"
 	args := []string{"cp", sourcePath, destPath}
-	log.Printf("Grabbing kubeconfig for cluster [%s]", c.String("name"))
 	if err := run(false, cmd, args...); err != nil {
 		log.Fatalf("FAILURE: couldn't get kubeconfig for cluster [%s] -> %+v", c.String("name"), err)
 		return err
 	}
-	log.Printf("SUCCESS: retrieved kubeconfig for cluster [%s]", c.String("name"))
-	fmt.Printf("%s", path.Join(destPath, "kubeconfig.yaml"))
+	fmt.Printf("%s\n", path.Join(destPath, "kubeconfig.yaml"))
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -39,8 +39,7 @@ func createCluster(c *cli.Context) error {
 		"--https-listen-port", c.String("port"), //args
 	)
 	log.Printf("Creating cluster [%s]", c.String("name"))
-	log.Printf("Running command: %+v", exec.Command(cmd, args...).Args)
-	if err := exec.Command(cmd, args...).Run(); err != nil {
+	if err := run(true, cmd, args...); err != nil {
 		log.Fatalf("FAILURE: couldn't create cluster [%s] -> %+v", c.String("name"), err)
 		return err
 	}
@@ -53,12 +52,10 @@ func deleteCluster(c *cli.Context) error {
 	cmd := "docker"
 	args := []string{"rm", c.String("name")}
 	log.Printf("Deleting cluster [%s]", c.String("name"))
-	log.Printf("Running command: %+v", exec.Command(cmd, args...).Args)
-	if err := exec.Command(cmd, args...).Run(); err != nil {
+	if err := run(true, cmd, args...); err != nil {
 		log.Printf("WARNING: couldn't delete cluster [%s], trying a force remove now.", c.String("name"))
 		args = append(args, "-f")
-		log.Printf("Running command: %+v", exec.Command(cmd, args...).Args)
-		if err := exec.Command(cmd, args...).Run(); err != nil {
+		if err := run(true, cmd, args...); err != nil {
 			log.Fatalf("FAILURE: couldn't delete cluster [%s] -> %+v", c.String("name"), err)
 			return err
 		}
@@ -73,8 +70,7 @@ func stopCluster(c *cli.Context) error {
 	cmd := "docker"
 	args := []string{"stop", c.String("name")}
 	log.Printf("Stopping cluster [%s]", c.String("name"))
-	log.Printf("Running command: %+v", exec.Command(cmd, args...).Args)
-	if err := exec.Command(cmd, args...).Run(); err != nil {
+	if err := run(true, cmd, args...); err != nil {
 		log.Fatalf("FAILURE: couldn't stop cluster [%s] -> %+v", c.String("name"), err)
 		return err
 	}
@@ -87,8 +83,7 @@ func startCluster(c *cli.Context) error {
 	cmd := "docker"
 	args := []string{"start", c.String("name")}
 	log.Printf("Starting cluster [%s]", c.String("name"))
-	log.Printf("Running command: %+v", exec.Command(cmd, args...).Args)
-	if err := exec.Command(cmd, args...).Run(); err != nil {
+	if err := run(true, cmd, args...); err != nil {
 		log.Fatalf("FAILURE: couldn't start cluster [%s] -> %+v", c.String("name"), err)
 		return err
 	}
@@ -109,8 +104,7 @@ func getKubeConfig(c *cli.Context) error {
 	cmd := "docker"
 	args := []string{"cp", sourcePath, destPath}
 	log.Printf("Grabbing kubeconfig for cluster [%s]", c.String("name"))
-	log.Printf("Running command: %+v", exec.Command(cmd, args...).Args)
-	if err := exec.Command(cmd, args...).Run(); err != nil {
+	if err := run(false, cmd, args...); err != nil {
 		log.Fatalf("FAILURE: couldn't get kubeconfig for cluster [%s] -> %+v", c.String("name"), err)
 		return err
 	}
@@ -146,7 +140,7 @@ func main() {
 				log.Print("Checking docker...")
 				cmd := "docker"
 				args := []string{"version"}
-				if err := exec.Command(cmd, args...).Run(); err != nil {
+				if err := run(true, cmd, args...); err != nil {
 					log.Fatalf("Checking docker: FAILED")
 					return err
 				}
@@ -248,4 +242,14 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+func run(verbose bool, name string, args ...string) error {
+	if verbose {
+		log.Printf("Running command: %+v", append([]string{name}, args...))
+	}
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }


### PR DESCRIPTION
Besides creating a helper method to run exec this also pipe stdout/err from
each call to the screen so that the user gets better feedback on what is
happening and why it might have failed.

After cluster create just print a simple command line to the screen to help
the user along.

Cluster create output now looks like

```
$ ./k3d-go c
2019/04/03 10:42:44 Creating cluster [k3s_default]
2019/04/03 10:42:44 Running command: [docker run --name k3s_default -e K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml --publish 6443:6443 --privileged -d rancher/k3s:v0.3.0 server --https-listen-port 6443]
0cead32193f1d3abc9219e85008a9230bc551921ba9c41a997a3bb542e3f8f0d
2019/04/03 10:42:44 SUCCESS: created cluster [k3s_default]
2019/04/03 10:42:44 You can now use the cluster with:

export KUBECONFIG="$(./k3d-go get-kubeconfig --name='k3s_default')"
kubectl cluster-info
```